### PR TITLE
Add Streaming Support for Generate and Chat Methods in Ollama Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ let weatherTool = Tool<WeatherInput, WeatherOutput>(
 >     ],
 >     required: ["city"]
 > ) { /* implementation */ }
-
+>
 > // ❌ Deprecated format (still works but not recommended)
 > let weatherTool = Tool<WeatherInput, WeatherOutput>(
 >     name: "get_current_weather",

--- a/README.md
+++ b/README.md
@@ -63,6 +63,33 @@ do {
 }
 ```
 
+#### Streaming text generation
+
+Generate text in a streaming fashion to receive responses in real-time:
+
+```swift
+do {
+    let stream = try await client.generateStream(
+        model: "llama3.2",
+        prompt: "Tell me a joke about Swift programming.",
+        options: [
+            "temperature": 0.7,
+            "max_tokens": 100
+        ]
+    )
+
+    var fullResponse = ""
+    for try await chunk in stream {
+        // Process each chunk of the response as it arrives
+        print(chunk.response, terminator: "")
+        fullResponse += chunk.response
+    }
+    print("\nFull response: \(fullResponse)")
+} catch {
+    print("Error: \(error)")
+}
+```
+
 ### Chatting with a model
 
 Generate a chat completion:
@@ -82,9 +109,71 @@ do {
 }
 ```
 
+#### Streaming chat responses
+
+Stream chat responses to get real-time partial completions:
+
+```swift
+do {
+    let stream = try await client.chatStream(
+        model: "llama3.2",
+        messages: [
+            .system("You are a helpful assistant."),
+            .user("Write a short poem about Swift programming.")
+        ]
+    )
+
+    var fullContent = ""
+    for try await chunk in stream {
+        // Process each chunk of the message as it arrives
+        if let content = chunk.message.content {
+            print(content, terminator: "")
+            fullContent += content
+        }
+    }
+    print("\nComplete poem: \(fullContent)")
+} catch {
+    print("Error: \(error)")
+}
+```
+
+You can also stream chat responses when using tools:
+
+```swift
+do {
+    let stream = try await client.chatStream(
+        model: "llama3.2",
+        messages: [
+            .system("You are a helpful assistant that can check the weather."),
+            .user("What's the weather like in Portland?")
+        ],
+        tools: [weatherTool]
+    )
+
+    for try await chunk in stream {
+        // Check if the model is making tool calls
+        if let toolCalls = chunk.message.toolCalls, !toolCalls.isEmpty {
+            print("Model is requesting tool: \(toolCalls[0].function.name)")
+        }
+
+        // Print content from the message as it streams
+        if let content = chunk.message.content {
+            print(content, terminator: "")
+        }
+
+        // Check if this is the final chunk
+        if chunk.done {
+            print("\nResponse complete")
+        }
+    }
+} catch {
+    print("Error: \(error)")
+}
+```
+
 ### Using Structured Outputs
 
-You can request structured outputs from models by specifying a format. 
+You can request structured outputs from models by specifying a format.
 Pass `"json"` to get back a JSON string,
 or specify a full [JSON Schema](https://json-schema.org):
 
@@ -159,7 +248,7 @@ struct WeatherOutput: Codable {
 let weatherTool = Tool<WeatherInput, WeatherOutput>(
     name: "get_current_weather",
     description: """
-    Get the current weather for a city, 
+    Get the current weather for a city,
     with conditions ("sunny", "cloudy", etc.)
     and temperature in °C.
     """,
@@ -229,22 +318,25 @@ enum ToolError {
 if let toolCall = response1.message.toolCalls?.first {
     // Parse the tool arguments
     guard let args = toolCall.function.arguments,
-          let red = Double(redStr, strict: false),
-          let green = Double(greenStr, strict: false),
-          let blue = Double(blueStr, strict: false) 
+          let redValue = args["red"],
+          let greenValue = args["green"],
+          let blueValue = args["blue"],
+          let red = Double(redValue, strict: false),
+          let green = Double(greenValue, strict: false),
+          let blue = Double(blueValue, strict: false)
     else {
         throw ToolError.invalidParameters
     }
-    
+
     let input = HexColorInput(
         red: red,
         green: green,
         blue: blue
     )
-    
+
     // Execute the tool with the input
     let hexColor = try await rgbToHexTool(input)
-    
+
     // Add the tool result to the conversation
     messages.append(.tool(hexColor))
 }
@@ -264,11 +356,11 @@ Generate embeddings for a given text:
 
 ```swift
 do {
-    let embeddings = try await client.createEmbeddings(
+    let response = try await client.embed(
         model: "llama3.2",
         input: "Here is an article about llamas..."
     )
-    print("Embeddings: \(embeddings)")
+    print("Embeddings: \(response.embeddings)")
 } catch {
     print("Error: \(error)")
 }

--- a/Sources/Ollama/Client.swift
+++ b/Sources/Ollama/Client.swift
@@ -157,6 +157,7 @@ open class Client {
         switch httpResponse.statusCode {
         case 200..<300:
             if T.self == Bool.self {
+                // If T is Bool, we return true for successful response
                 return true as! T
             } else if data.isEmpty {
                 throw Error.responseError(response: httpResponse, detail: "Empty response body")
@@ -374,7 +375,7 @@ extension Client {
             "model": .string(model.rawValue),
             "prompt": .string(prompt),
             "stream": .bool(stream),
-            "raw": .bool(raw)
+            "raw": .bool(raw),
         ]
 
         if let images = images {

--- a/Sources/Ollama/Client.swift
+++ b/Sources/Ollama/Client.swift
@@ -87,64 +87,6 @@ open class Client {
         case delete = "DELETE"
     }
 
-    private func createRequest(
-        _ method: Method,
-        _ path: String,
-        params: [String: Value]? = nil
-    ) throws -> URLRequest {
-        var urlComponents = URLComponents(url: host, resolvingAgainstBaseURL: true)
-        urlComponents?.path = path
-
-        var httpBody: Data? = nil
-        switch method {
-        case .get:
-            if let params {
-                var queryItems: [URLQueryItem] = []
-                for (key, value) in params {
-                    queryItems.append(URLQueryItem(name: key, value: value.description))
-                }
-                urlComponents?.queryItems = queryItems
-            }
-        case .post, .delete:
-            if let params {
-                let encoder = JSONEncoder()
-                httpBody = try encoder.encode(params)
-            }
-        }
-
-        guard let url = urlComponents?.url else {
-            throw Error.requestError(
-                #"Unable to construct URL with host "\#(host)" and path "\#(path)""#)
-        }
-        var request: URLRequest = URLRequest(url: url)
-        request.httpMethod = method.rawValue
-
-        request.addValue("application/json", forHTTPHeaderField: "Accept")
-        if let userAgent {
-            request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
-        }
-
-        if let httpBody {
-            request.httpBody = httpBody
-            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        }
-
-        return request
-    }
-
-    private func validateResponse(_ response: URLResponse) throws -> HTTPURLResponse {
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw Error.unexpectedError("Response is not HTTPURLResponse")
-        }
-        return httpResponse
-    }
-
-    private func createDecoder() -> JSONDecoder {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
-        return decoder
-    }
-
     func fetch<T: Decodable>(
         _ method: Method,
         _ path: String,
@@ -245,6 +187,64 @@ open class Client {
                 task.cancel()
             }
         }
+    }
+
+    private func createRequest(
+        _ method: Method,
+        _ path: String,
+        params: [String: Value]? = nil
+    ) throws -> URLRequest {
+        var urlComponents = URLComponents(url: host, resolvingAgainstBaseURL: true)
+        urlComponents?.path = path
+
+        var httpBody: Data? = nil
+        switch method {
+        case .get:
+            if let params {
+                var queryItems: [URLQueryItem] = []
+                for (key, value) in params {
+                    queryItems.append(URLQueryItem(name: key, value: value.description))
+                }
+                urlComponents?.queryItems = queryItems
+            }
+        case .post, .delete:
+            if let params {
+                let encoder = JSONEncoder()
+                httpBody = try encoder.encode(params)
+            }
+        }
+
+        guard let url = urlComponents?.url else {
+            throw Error.requestError(
+                #"Unable to construct URL with host "\#(host)" and path "\#(path)""#)
+        }
+        var request: URLRequest = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        if let userAgent {
+            request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
+        }
+
+        if let httpBody {
+            request.httpBody = httpBody
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        return request
+    }
+
+    private func validateResponse(_ response: URLResponse) throws -> HTTPURLResponse {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw Error.unexpectedError("Response is not HTTPURLResponse")
+        }
+        return httpResponse
+    }
+
+    private func createDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
+        return decoder
     }
 }
 

--- a/Sources/Ollama/Client.swift
+++ b/Sources/Ollama/Client.swift
@@ -231,7 +231,7 @@ extension Client {
         system: String? = nil,
         template: String? = nil,
         context: [Int]? = nil,
-        stream: Bool = true,
+        stream: Bool = false,
         raw: Bool = false
     )
         async throws -> GenerateResponse

--- a/Tests/OllamaTests/ClientTests.swift
+++ b/Tests/OllamaTests/ClientTests.swift
@@ -16,8 +16,7 @@ final class ClientTests: XCTestCase {
         let response = try await ollama.generate(
             model: "llama3.2",
             prompt: prompt,
-            images: [imageData],
-            stream: false
+            images: [imageData]
         )
 
         XCTAssertFalse(response.response.isEmpty)
@@ -29,6 +28,20 @@ final class ClientTests: XCTestCase {
         XCTAssertGreaterThan(response.promptEvalCount ?? 0, 0)
     }
     
+    func testGenerateStream() async throws {
+        let response = ollama.generateStream(
+            model: "llama3.2",
+            prompt: "[System]: You are a helpful AI assistant. \n [User]: Write a haiku about llamas."
+        )
+        
+        var collect: [String] = []
+        for try await res in response {
+            collect.append(res.response)
+        }
+
+        XCTAssertFalse(collect.isEmpty)
+    }
+
     func testChatCompletion() async throws {
         let messages: [Chat.Message] = [
             .system("You are a helpful AI assistant."),
@@ -40,12 +53,23 @@ final class ClientTests: XCTestCase {
             messages: messages)
         XCTAssertFalse(response.message.content.isEmpty)
     }
-    
-    func testGenerateCompletion() async throws {
-        let response = try await ollama.generate(
+
+    func testChatStream() async throws {
+        let messages: [Chat.Message] = [
+            .system("You are a helpful AI assistant."),
+            .user("Write a haiku about llamas."),
+        ]
+
+        let response = try ollama.chatStream(
             model: "llama3.2",
-            prompt: "[System]: You are a helpful AI assistant. \n [User]: Write a haiku about llamas.")
-        XCTAssertFalse(response.response.isEmpty)
+            messages: messages)
+        
+        var collect: [String] = []
+        for try await res in response {
+            collect.append(res.message.content)
+        }
+
+        XCTAssertFalse(collect.isEmpty)
     }
 
     func testEmbed() async throws {

--- a/Tests/OllamaTests/ClientTests.swift
+++ b/Tests/OllamaTests/ClientTests.swift
@@ -28,7 +28,7 @@ final class ClientTests: XCTestCase {
         XCTAssertGreaterThan(response.loadDuration ?? 0, 0)
         XCTAssertGreaterThan(response.promptEvalCount ?? 0, 0)
     }
-
+    
     func testChatCompletion() async throws {
         let messages: [Chat.Message] = [
             .system("You are a helpful AI assistant."),
@@ -39,6 +39,13 @@ final class ClientTests: XCTestCase {
             model: "llama3.2",
             messages: messages)
         XCTAssertFalse(response.message.content.isEmpty)
+    }
+    
+    func testGenerateCompletion() async throws {
+        let response = try await ollama.generate(
+            model: "llama3.2",
+            prompt: "[System]: You are a helpful AI assistant. \n [User]: Write a haiku about llamas.")
+        XCTAssertFalse(response.response.isEmpty)
     }
 
     func testEmbed() async throws {

--- a/Tests/OllamaTests/ClientTests.swift
+++ b/Tests/OllamaTests/ClientTests.swift
@@ -32,19 +32,18 @@ struct ClientTests {
         #expect(!response.response.isEmpty)
         #expect(response.done)
         #expect(response.model == "llama3.2")
-        #expect(response.createdAt != nil)
         #expect(response.totalDuration ?? 0 > 0)
         #expect(response.loadDuration ?? 0 > 0)
         #expect(response.promptEvalCount ?? 0 > 0)
     }
-    
+
     @Test
     func testGenerateStream() async throws {
         let response = await ollama.generateStream(
             model: "llama3.2",
-            prompt: "[System]: You are a helpful AI assistant. \n [User]: Write a haiku about llamas."
+            prompt: "Write a haiku about llamas."
         )
-        
+
         var collect: [String] = []
         for try await res in response {
             collect.append(res.response)
@@ -76,7 +75,7 @@ struct ClientTests {
         let response = try await ollama.chatStream(
             model: "llama3.2",
             messages: messages)
-        
+
         var collect: [String] = []
         for try await res in response {
             collect.append(res.message.content)
@@ -106,11 +105,7 @@ struct ClientTests {
 
     @Test
     func testListRunningModels() async throws {
-        let response = try await ollama.listRunningModels()
-
-        // This test might be flaky if no models are running
-        // Consider starting a model before running this test
-        #expect(response != nil)
+        let _ = try await ollama.listRunningModels()
     }
 
     @Test(.disabled())
@@ -291,6 +286,55 @@ struct ClientTests {
         #expect(red == 1.0)
         #expect(green == 1.0)
         #expect(blue == 0.0)
+    }
+
+    @Test
+    func testChatStreamWithTool() async throws {
+        let messages: [Chat.Message] = [
+            .system(
+                """
+                You are a helpful AI assistant that can convert colors.
+                When asked about colors, use the rgb_to_hex tool to convert them.
+                """),
+            .user("What's the hex code for yellow?"),
+        ]
+
+        let stream = try await ollama.chatStream(
+            model: "llama3.2",
+            messages: messages,
+            tools: [hexColorTool]
+        )
+
+        var foundToolCall = false
+
+        for try await res in stream {
+            // Check for tool calls in the message
+            if let toolCalls = res.message.toolCalls,
+                let toolCall = toolCalls.first,
+                toolCall.function.name == "rgb_to_hex"
+            {
+                foundToolCall = true
+
+                // Check if we can get the color values
+                if let redValue = toolCall.function.arguments["red"],
+                    let greenValue = toolCall.function.arguments["green"],
+                    let blueValue = toolCall.function.arguments["blue"]
+                {
+                    // Try to convert to Double and validate
+                    if let redDouble = Double(redValue, strict: false),
+                        let greenDouble = Double(greenValue, strict: false),
+                        let blueDouble = Double(blueValue, strict: false)
+                    {
+                        // Verify yellow color values (1.0, 1.0, 0.0)
+                        #expect(redDouble == 1.0, "Invalid red value: \(redDouble)")
+                        #expect(greenDouble == 1.0, "Invalid green value: \(greenDouble)")
+                        #expect(blueDouble == 0.0, "Invalid blue value: \(blueDouble)")
+                    }
+                }
+            }
+        }
+
+        #expect(foundToolCall, "No tool call found in any stream message")
     }
 
     @Test


### PR DESCRIPTION
Hi @mattt, thank you for your work. 

I’ve been using this package in my CLI app and thought it would be great to add streaming support. This feature allows for a more intuitive experience, as updates can be seen in real-time rather than waiting for the entire response.

This PR enhances the client library by introducing incremental streaming responses.

#### **Streaming Support in Methods:**
   - **`generateStream` Method:** 
     - Adds a new method to support streaming responses from the generate endpoint.
     - Returns an `AsyncThrowingStream<ChatResponse, Swift.Error>` to allow processing responses incrementally.
  
   - **`chatStream` Method:** 
     - Adds a method to support streaming responses from the chat endpoint, similar to the `generateStream`.
     - Returns an `AsyncThrowingStream<ChatResponse, Swift.Error>` for incremental response handling.

### Demo:

https://github.com/user-attachments/assets/b0e954cb-5b01-48a7-8d5b-cb88f1539d68

### Usage:

```swift
let stream = try await client.generateStream(
    model: "llama3.2",
    prompt: "[System]: You are a helpful AI assistant. \n [User]: Write a haiku about llamas."
)

do {
    for try await value in stream {
        print(value.response, terminator: "")
    }
    print()
} catch {
   // Handle error.
}

```

Let me know if you need anything else!