### PR TITLE
Add support for thinking in client generation methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,49 @@ let response = try await client.chat(
 
 The format parameter works with both `chat` and `generate` methods.
 
+### Using Thinking Models
+
+Some models support a "thinking" mode
+where they show their reasoning process before providing the final answer. 
+This is particularly useful for complex reasoning tasks.
+
+```swift
+// Generate with thinking enabled
+let response = try await client.generate(
+    model: "deepseek-r1:8b",
+    prompt: "What is 17 * 23? Show your work.",
+    think: true
+)
+
+print("Thinking: \(response.thinking ?? "None")")
+print("Answer: \(response.response)")
+```
+
+You can also use thinking in chat conversations:
+
+```swift
+let response = try await client.chat(
+    model: "deepseek-r1:8b",
+    messages: [
+        .system("You are a helpful mathematician."),
+        .user("Calculate 9.9 + 9.11 and explain your reasoning.")
+    ],
+    think: true
+)
+
+print("Thinking: \(response.message.thinking ?? "None")")
+print("Response: \(response.message.content)")
+```
+
+> [!TIP]
+> You can check which models support thinking by examining their capabilities:
+> ```swift
+> let modelInfo = try await client.showModel("deepseek-r1:8b")
+> if modelInfo.capabilities.contains(.thinking) {
+>     print("🧠 This model supports thinking!")
+> }
+> ```
+
 ### Managing Model Memory with Keep-Alive
 
 You can control how long a model stays loaded in memory using the `keepAlive` parameter. This is useful for managing memory usage and response times.

--- a/Sources/Ollama/Chat.swift
+++ b/Sources/Ollama/Chat.swift
@@ -57,6 +57,9 @@ public enum Chat {
         /// Optional array of tool calls associated with the message
         public let toolCalls: [ToolCall]?
 
+        /// The thinking process of the assistant when thinking is enabled
+        public let thinking: String?
+
         /// Creates a new chat message.
         ///
         /// - Parameters:
@@ -64,16 +67,19 @@ public enum Chat {
         ///   - content: The content of the message.
         ///   - images: Optional array of image data associated with the message.
         ///   - toolCalls: Optional array of tool calls associated with the message.
+        ///   - thinking: The thinking process of the assistant when thinking is enabled.
         private init(
             role: Role,
             content: String,
             images: [Data]? = nil,
-            toolCalls: [ToolCall]? = nil
+            toolCalls: [ToolCall]? = nil,
+            thinking: String? = nil
         ) {
             self.role = role
             self.content = content
             self.images = images
             self.toolCalls = toolCalls
+            self.thinking = thinking
         }
 
         /// Creates a system message.
@@ -116,17 +122,20 @@ public enum Chat {
         ///   - content: The content of the message.
         ///   - images: Optional array of image data associated with the message.
         ///   - toolCalls: Optional array of tool calls associated with the message.
+        ///   - thinking: The thinking process of the assistant when thinking is enabled.
         /// - Returns: A new `Message` instance with the assistant role.
         public static func assistant(
             _ content: String,
             images: [Data]? = nil,
-            toolCalls: [ToolCall]? = nil
+            toolCalls: [ToolCall]? = nil,
+            thinking: String? = nil
         ) -> Message {
             return Message(
                 role: .assistant,
                 content: content,
                 images: images,
-                toolCalls: toolCalls
+                toolCalls: toolCalls,
+                thinking: thinking
             )
         }
 
@@ -150,6 +159,7 @@ extension Chat.Message: Codable {
         case content
         case images
         case toolCalls = "tool_calls"
+        case thinking
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -159,6 +169,7 @@ extension Chat.Message: Codable {
         try container.encode(content, forKey: .content)
         try container.encodeIfPresent(images, forKey: .images)
         try container.encodeIfPresent(toolCalls, forKey: .toolCalls)
+        try container.encodeIfPresent(thinking, forKey: .thinking)
     }
 
     public init(from decoder: Decoder) throws {
@@ -168,5 +179,6 @@ extension Chat.Message: Codable {
         content = try container.decode(String.self, forKey: .content)
         images = try container.decodeIfPresent([Data].self, forKey: .images)
         toolCalls = try container.decodeIfPresent([ToolCall].self, forKey: .toolCalls)
+        thinking = try container.decodeIfPresent(String.self, forKey: .thinking)
     }
 }

--- a/Tests/OllamaTests/KeepAliveTests.swift
+++ b/Tests/OllamaTests/KeepAliveTests.swift
@@ -234,24 +234,21 @@ struct KeepAliveTests {
             let hours: KeepAlive.Duration = .hours(2)
 
             // Test structure
-            switch seconds {
-            case .seconds(let value):
+            if case .seconds(let value) = seconds {
                 #expect(value == 30)
-            default:
+            } else {
                 Issue.record("Expected .seconds(30)")
             }
 
-            switch minutes {
-            case .minutes(let value):
+            if case .minutes(let value) = minutes {
                 #expect(value == 5)
-            default:
+            } else {
                 Issue.record("Expected .minutes(5)")
             }
 
-            switch hours {
-            case .hours(let value):
+            if case .hours(let value) = hours {
                 #expect(value == 2)
-            default:
+            } else {
                 Issue.record("Expected .hours(2)")
             }
         }


### PR DESCRIPTION
This PR adds the `think` parameter to `Client.generate(...)`, `Client.generateStream(...)`, and `Client.chat(...)`. Models with the `thinking` capability (#17) will emit `thinking` tokens in their response.