### PR TITLE
Fix Swift 6 strict concurrency warning in fetchStream

### DIFF
--- a/Sources/Ollama/Client.swift
+++ b/Sources/Ollama/Client.swift
@@ -134,7 +134,7 @@ public final class Client: Sendable {
         }
     }
 
-    func fetchStream<T: Decodable>(
+    func fetchStream<T: Decodable & Sendable>(
         _ method: Method,
         _ path: String,
         params: [String: Value]? = nil


### PR DESCRIPTION
This PR adds the Sendable constraint to the generic type parameter in fetchStream to fix Swift 6 strict concurrency warnings.

The error occurs when passing decoded values to continuation.yield() because Swift 6 requires types passed across concurrency boundaries to be Sendable.

Error fixed:
```
Client.swift:185:46: error: sending 'decoded' risks causing data races
continuation.yield(decoded)
```

The fix adds `& Sendable` constraint to the generic type T in fetchStream method signature.