### PR TITLE
Simplify structured output using

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 let package = Package(
     name: "Ollama",
     platforms: [
-        .macOS(.v13),
+        .macOS(.v12),
         .macCatalyst(.v13),
         .iOS(.v16),
         .watchOS(.v9),

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Ollama",
     platforms: [
-        .macOS(.v13),
+        .macOS(.v12),
         .macCatalyst(.v13),
         .iOS(.v16),
         .watchOS(.v9),

--- a/README.md
+++ b/README.md
@@ -175,8 +175,66 @@ do {
 ### Using Structured Outputs
 
 You can request structured outputs from models by specifying a format.
-Pass `"json"` to get back a JSON string,
-or specify a full [JSON Schema](https://json-schema.org):
+The library provides several ways to generate JSON schemas automatically from your Swift types,
+making it easy to get structured responses without manually writing schemas.
+
+#### Automatic Schema Generation (Recommended)
+
+The easiest way to use structured outputs is to define a Swift type and let the library
+automatically generate the JSON schema. This works in two ways:
+
+**1. Using `JSONSchemaExample` (for types with required properties):**
+
+```swift
+import Ollama
+
+struct Country: Codable, JSONSchemaExample {
+    let name: String
+    let capital: String
+    let languages: [String]
+    
+    static var example: Country {
+        Country(
+            name: "Canada",
+            capital: "Ottawa",
+            languages: ["English", "French"]
+        )
+    }
+}
+
+// Schema is automatically generated from the example!
+// The response is automatically decoded to your type
+let (country, _) = try await client.chat(
+    model: "llama3.2",
+    messages: [.user("Tell me about Canada.")],
+    responseType: Country.self
+)
+
+print(country.name)      // "Canada"
+print(country.capital)   // "Ottawa"
+print(country.languages) // ["English", "French"]
+```
+
+**2. Automatic generation for optional properties:**
+
+```swift
+struct Color: Codable {
+    let name: String?
+    let hex: String?
+    let rgb: [Int]?
+}
+
+// Works automatically - no example needed!
+let (color, _) = try await client.chat(
+    model: "llama3.2",
+    messages: [.user("Give me a color and its hex code.")],
+    responseType: Color.self
+)
+```
+
+#### Manual Schema Definition
+
+You can also manually specify a JSON schema for full control:
 
 ```swift
 // Simple JSON format
@@ -221,7 +279,64 @@ let response = try await client.chat(
 // }
 ```
 
-The format parameter works with both `chat` and `generate` methods.
+#### Custom Schema with `JSONSchemaRepresentable`
+
+For advanced use cases, you can provide a custom schema:
+
+```swift
+struct Country: Codable, JSONSchemaRepresentable {
+    let name: String
+    let capital: String
+    let languages: [String]
+    
+    static var jsonSchema: Value {
+        [
+            "type": "object",
+            "properties": [
+                "name": ["type": "string", "description": "Country name"],
+                "capital": ["type": "string", "description": "Capital city"],
+                "languages": [
+                    "type": "array",
+                    "items": ["type": "string"],
+                    "description": "Official languages"
+                ]
+            ],
+            "required": ["name", "capital", "languages"]
+        ]
+    }
+}
+
+let (country, _) = try await client.chat(
+    model: "llama3.2",
+    messages: [.user("Tell me about Canada.")],
+    responseType: Country.self
+)
+```
+
+#### Using with `generate` method
+
+Structured outputs also work with the `generate` method:
+
+```swift
+struct Joke: Codable, JSONSchemaExample {
+    let setup: String
+    let punchline: String
+    
+    static var example: Joke {
+        Joke(setup: "Why did the Swift developer...", punchline: "Because...")
+    }
+}
+
+let (joke, _) = try await client.generate(
+    model: "llama3.2",
+    prompt: "Tell me a programming joke.",
+    responseType: Joke.self
+)
+```
+
+> [!TIP]
+> The format parameter works with both `chat` and `generate` methods, including their streaming variants.
+> For streaming responses, the library accumulates the content and decodes the final JSON when complete.
 
 ### Using Thinking Models
 

--- a/Sources/Ollama/Client.swift
+++ b/Sources/Ollama/Client.swift
@@ -193,7 +193,7 @@ public final class Client: Sendable {
                 }
             }
 
-            continuation.onTermination = { _ in
+            continuation.onTermination = { @Sendable _ in
                 task.cancel()
             }
         }
@@ -662,6 +662,321 @@ extension Client {
         }
 
         return params
+    }
+}
+
+// MARK: - Structured Outputs
+
+extension Client {
+    /// Generates the next message in a chat with structured output.
+    ///
+    /// This method automatically generates a JSON schema from the provided type
+    /// and uses it to constrain the model's output format.
+    ///
+    /// - Parameters:
+    ///   - model: The name of the model to use for the chat.
+    ///   - messages: The messages of the chat, used to keep a chat memory.
+    ///   - responseType: The Codable type that the response should conform to.
+    ///   - options: Additional model parameters as specified in the Modelfile documentation.
+    ///   - template: The prompt template to use (overrides what is defined in the Modelfile).
+    ///   - tools: Optional array of tools that can be called by the model.
+    ///   - think: If true, the model will think about the response before responding. Requires thinking support from the model.
+    ///   - keepAlive: Controls how long the model will stay loaded into memory following the request. Defaults to `.default` which uses the server's default (typically 5 minutes).
+    /// - Returns: A tuple containing the decoded response of type `ResponseType` and the original `ChatResponse`.
+    /// - Throws: An error if the request fails, the response cannot be decoded, or the schema cannot be generated.
+    ///
+    /// - Example:
+    /// ```swift
+    /// struct Country: Codable, JSONSchemaRepresentable {
+    ///     let name: String
+    ///     let capital: String
+    ///     let languages: [String]
+    ///     
+    ///     static var jsonSchema: Value {
+    ///         [
+    ///             "type": "object",
+    ///             "properties": [
+    ///                 "name": ["type": "string"],
+    ///                 "capital": ["type": "string"],
+    ///                 "languages": [
+    ///                     "type": "array",
+    ///                     "items": ["type": "string"]
+    ///                 ]
+    ///             ],
+    ///             "required": ["name", "capital", "languages"]
+    ///         ]
+    ///     }
+    /// }
+    ///
+    /// let (country, response) = try await client.chat(
+    ///     model: "llama3.2",
+    ///     messages: [.user("Tell me about Canada.")],
+    ///     responseType: Country.self
+    /// )
+    /// ```
+    public func chat<ResponseType: Codable>(
+        model: Model.ID,
+        messages: [Chat.Message],
+        responseType: ResponseType.Type,
+        options: [String: Value]? = nil,
+        template: String? = nil,
+        tools: [any ToolProtocol]? = nil,
+        think: Bool? = nil,
+        keepAlive: KeepAlive = .default
+    ) async throws -> (response: ResponseType, rawResponse: ChatResponse) {
+        let schema = try JSONSchemaGenerator.schema(for: responseType)
+        let chatResponse = try await chat(
+            model: model,
+            messages: messages,
+            options: options,
+            template: template,
+            format: schema,
+            tools: tools,
+            think: think,
+            keepAlive: keepAlive
+        )
+        
+        let decoder = JSONDecoder()
+        let responseData = chatResponse.message.content.data(using: .utf8) ?? Data()
+        let decodedResponse = try decoder.decode(ResponseType.self, from: responseData)
+        
+        return (decodedResponse, chatResponse)
+    }
+    
+    /// Generates a streaming chat response with structured output.
+    ///
+    /// This method automatically generates a JSON schema from the provided type
+    /// and uses it to constrain the model's output format.
+    ///
+    /// - Parameters:
+    ///   - model: The name of the model to use for the chat.
+    ///   - messages: The messages of the chat, used to keep a chat memory.
+    ///   - responseType: The Codable type that the response should conform to.
+    ///   - options: Additional model parameters as specified in the Modelfile documentation.
+    ///   - template: The prompt template to use (overrides what is defined in the Modelfile).
+    ///   - tools: Optional array of tools that can be called by the model.
+    ///   - think: If true, the model will think about the response before responding. Requires thinking support from the model.
+    ///   - keepAlive: Controls how long the model will stay loaded into memory following the request. Defaults to `.default` which uses the server's default (typically 5 minutes).
+    /// - Returns: An async throwing stream of tuples containing decoded responses of type `ResponseType` and the original `ChatResponse`.
+    /// - Throws: An error if the request fails or the schema cannot be generated.
+    ///
+    /// - Note: For streaming responses, you'll need to accumulate the content chunks and decode the final complete JSON.
+    public func chatStream<ResponseType: Codable & Sendable>(
+        model: Model.ID,
+        messages: [Chat.Message],
+        responseType: ResponseType.Type,
+        options: [String: Value]? = nil,
+        template: String? = nil,
+        tools: [any ToolProtocol]? = nil,
+        think: Bool? = nil,
+        keepAlive: KeepAlive = .default
+    ) throws -> AsyncThrowingStream<(response: ResponseType?, rawResponse: ChatResponse), Swift.Error> {
+        let schema = try JSONSchemaGenerator.schema(for: responseType)
+        let stream = try chatStream(
+            model: model,
+            messages: messages,
+            options: options,
+            template: template,
+            format: schema,
+            tools: tools,
+            think: think,
+            keepAlive: keepAlive
+        )
+        
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                var accumulatedContent = ""
+                do {
+                    for try await chatResponse in stream {
+                        accumulatedContent += chatResponse.message.content
+                        
+                        // Try to decode if the response is done
+                        let decodedResponse: ResponseType? = {
+                            guard chatResponse.done else { return nil }
+                            guard let data = accumulatedContent.data(using: .utf8) else { return nil }
+                            return try? JSONDecoder().decode(ResponseType.self, from: data)
+                        }()
+                        
+                        continuation.yield((decodedResponse, chatResponse))
+                        
+                        if chatResponse.done {
+                            continuation.finish()
+                            return
+                        }
+                    }
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+}
+
+// MARK: - Structured Outputs for Generate
+
+extension Client {
+    /// Generates a response for a given prompt with structured output.
+    ///
+    /// This method automatically generates a JSON schema from the provided type
+    /// and uses it to constrain the model's output format.
+    ///
+    /// - Parameters:
+    ///   - model: The name of the model to use for generation.
+    ///   - prompt: The prompt to generate a response for.
+    ///   - responseType: The Codable type that the response should conform to.
+    ///   - images: Optional list of base64-encoded images (for multimodal models).
+    ///   - options: Additional model parameters as specified in the Modelfile documentation.
+    ///   - system: System message to override what is defined in the Modelfile.
+    ///   - template: The prompt template to use (overrides what is defined in the Modelfile).
+    ///   - context: The context parameter returned from a previous request to keep a short conversational memory.
+    ///   - raw: If true, no formatting will be applied to the prompt.
+    ///   - think: If true, the model will think about the response before responding. Requires thinking support from the model.
+    ///   - keepAlive: Controls how long the model will stay loaded into memory following the request. Defaults to `.default` which uses the server's default (typically 5 minutes).
+    /// - Returns: A tuple containing the decoded response of type `ResponseType` and the original `GenerateResponse`.
+    /// - Throws: An error if the request fails, the response cannot be decoded, or the schema cannot be generated.
+    ///
+    /// - Example:
+    /// ```swift
+    /// struct Color: Codable, JSONSchemaRepresentable {
+    ///     let name: String
+    ///     let hex: String
+    ///     
+    ///     static var jsonSchema: Value {
+    ///         [
+    ///             "type": "object",
+    ///             "properties": [
+    ///                 "name": ["type": "string"],
+    ///                 "hex": ["type": "string"]
+    ///             ],
+    ///             "required": ["name", "hex"]
+    ///         ]
+    ///     }
+    /// }
+    ///
+    /// let (color, response) = try await client.generate(
+    ///     model: "llama3.2",
+    ///     prompt: "Give me a color and its hex code.",
+    ///     responseType: Color.self
+    /// )
+    /// ```
+    public func generate<ResponseType: Codable>(
+        model: Model.ID,
+        prompt: String,
+        responseType: ResponseType.Type,
+        images: [Data]? = nil,
+        options: [String: Value]? = nil,
+        system: String? = nil,
+        template: String? = nil,
+        context: [Int]? = nil,
+        raw: Bool = false,
+        think: Bool? = nil,
+        keepAlive: KeepAlive = .default
+    ) async throws -> (response: ResponseType, rawResponse: GenerateResponse) {
+        let schema = try JSONSchemaGenerator.schema(for: responseType)
+        let generateResponse = try await generate(
+            model: model,
+            prompt: prompt,
+            images: images,
+            format: schema,
+            options: options,
+            system: system,
+            template: template,
+            context: context,
+            raw: raw,
+            think: think,
+            keepAlive: keepAlive
+        )
+        
+        let decoder = JSONDecoder()
+        let responseData = generateResponse.response.data(using: .utf8) ?? Data()
+        let decodedResponse = try decoder.decode(ResponseType.self, from: responseData)
+        
+        return (decodedResponse, generateResponse)
+    }
+    
+    /// Generates a streaming response for a given prompt with structured output.
+    ///
+    /// This method automatically generates a JSON schema from the provided type
+    /// and uses it to constrain the model's output format.
+    ///
+    /// - Parameters:
+    ///   - model: The name of the model to use for generation.
+    ///   - prompt: The prompt to generate a response for.
+    ///   - responseType: The Codable type that the response should conform to.
+    ///   - images: Optional list of base64-encoded images (for multimodal models).
+    ///   - options: Additional model parameters as specified in the Modelfile documentation.
+    ///   - system: System message to override what is defined in the Modelfile.
+    ///   - template: The prompt template to use (overrides what is defined in the Modelfile).
+    ///   - context: The context parameter returned from a previous request to keep a short conversational memory.
+    ///   - raw: If true, no formatting will be applied to the prompt.
+    ///   - think: If true, the model will think about the response before responding. Requires thinking support from the model.
+    ///   - keepAlive: Controls how long the model will stay loaded into memory following the request. Defaults to `.default` which uses the server's default (typically 5 minutes).
+    /// - Returns: An async throwing stream of tuples containing decoded responses of type `ResponseType` and the original `GenerateResponse`.
+    /// - Throws: An error if the request fails or the schema cannot be generated.
+    ///
+    /// - Note: For streaming responses, you'll need to accumulate the response chunks and decode the final complete JSON.
+    public func generateStream<ResponseType: Codable & Sendable>(
+        model: Model.ID,
+        prompt: String,
+        responseType: ResponseType.Type,
+        images: [Data]? = nil,
+        options: [String: Value]? = nil,
+        system: String? = nil,
+        template: String? = nil,
+        context: [Int]? = nil,
+        raw: Bool = false,
+        think: Bool? = nil,
+        keepAlive: KeepAlive = .default
+    ) throws -> AsyncThrowingStream<(response: ResponseType?, rawResponse: GenerateResponse), Swift.Error> {
+        let schema = try JSONSchemaGenerator.schema(for: responseType)
+        let stream = generateStream(
+            model: model,
+            prompt: prompt,
+            images: images,
+            format: schema,
+            options: options,
+            system: system,
+            template: template,
+            context: context,
+            raw: raw,
+            think: think,
+            keepAlive: keepAlive
+        )
+        
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                var accumulatedResponse = ""
+                do {
+                    for try await generateResponse in stream {
+                        accumulatedResponse += generateResponse.response
+                        
+                        // Try to decode if the response is done
+                        let decodedResponse: ResponseType? = {
+                            guard generateResponse.done else { return nil }
+                            guard let data = accumulatedResponse.data(using: .utf8) else { return nil }
+                            return try? JSONDecoder().decode(ResponseType.self, from: data)
+                        }()
+                        
+                        continuation.yield((decodedResponse, generateResponse))
+                        
+                        if generateResponse.done {
+                            continuation.finish()
+                            return
+                        }
+                    }
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
     }
 }
 

--- a/Sources/Ollama/Extensions/Data+Extensions.swift
+++ b/Sources/Ollama/Extensions/Data+Extensions.swift
@@ -1,8 +1,13 @@
 import Foundation
+
+#if canImport(RegexBuilder)
 import RegexBuilder
+#endif
 
 extension Data {
-    /// Regex pattern for data URLs
+    #if canImport(RegexBuilder)
+    /// Regex pattern for data URLs (macOS 13.0+ / iOS 16.0+)
+    @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     @inline(__always) private static var dataURLRegex:
         Regex<(Substring, Substring, Substring?, Substring)>
     {
@@ -28,6 +33,12 @@ extension Data {
             }
         }
     }
+    #endif
+
+    /// NSRegularExpression pattern for data URLs (macOS 12.0+ fallback)
+    private static var dataURLPattern: String {
+        "^data:([^,;]*)(?:;charset=([^,;]+))?(?:;base64)?,(.*)$"
+    }
 
     /// Checks if a given string is a valid data URL.
     ///
@@ -35,7 +46,18 @@ extension Data {
     /// - Returns: `true` if the string is a valid data URL, otherwise `false`.
     /// - SeeAlso: [RFC 2397](https://www.rfc-editor.org/rfc/rfc2397.html)
     public static func isDataURL(string: String) -> Bool {
-        return string.wholeMatch(of: dataURLRegex) != nil
+        #if canImport(RegexBuilder)
+        if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
+            return string.wholeMatch(of: dataURLRegex) != nil
+        }
+        #endif
+
+        // Fallback for macOS 12.0+
+        guard let regex = try? NSRegularExpression(pattern: dataURLPattern, options: []) else {
+            return false
+        }
+        let range = NSRange(string.startIndex..<string.endIndex, in: string)
+        return regex.firstMatch(in: string, options: [], range: range) != nil
     }
 
     /// Parses a data URL string into its MIME type and data components.
@@ -44,17 +66,73 @@ extension Data {
     /// - Returns: A tuple containing the MIME type and decoded data, or `nil` if parsing fails.
     /// - SeeAlso: [RFC 2397](https://www.rfc-editor.org/rfc/rfc2397.html)
     public static func parseDataURL(_ string: String) -> (mimeType: String, data: Data)? {
-        guard let match = string.wholeMatch(of: dataURLRegex) else {
+        #if canImport(RegexBuilder)
+        if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
+            guard let match = string.wholeMatch(of: dataURLRegex) else {
+                return nil
+            }
+
+            // Extract components using strongly typed captures
+            let (_, mediatype, charset, encodedData) = match.output
+
+            let isBase64 = string.contains(";base64,")
+
+            // Process MIME type
+            var mimeType = mediatype.isEmpty ? "text/plain" : String(mediatype)
+            if let charset = charset, !charset.isEmpty, mimeType.starts(with: "text/") {
+                mimeType += ";charset=\(charset)"
+            }
+
+            // Decode data
+            let decodedData: Data
+            if isBase64 {
+                guard let base64Data = Data(base64Encoded: String(encodedData)) else { return nil }
+                decodedData = base64Data
+            } else {
+                guard
+                    let percentDecodedData = String(encodedData).removingPercentEncoding?.data(
+                        using: .utf8)
+                else { return nil }
+                decodedData = percentDecodedData
+            }
+
+            return (mimeType: mimeType, data: decodedData)
+        }
+        #endif
+
+        // Fallback for macOS 12.0+
+        guard let regex = try? NSRegularExpression(pattern: dataURLPattern, options: []) else {
+            return nil
+        }
+        let range = NSRange(string.startIndex..<string.endIndex, in: string)
+        guard let match = regex.firstMatch(in: string, options: [], range: range) else {
             return nil
         }
 
-        // Extract components using strongly typed captures
-        let (_, mediatype, charset, encodedData) = match.output
+        // Extract components from NSRegularExpression match
+        guard match.numberOfRanges >= 4 else { return nil }
+        
+        let mediatypeRange = Range(match.range(at: 1), in: string) ?? string.startIndex..<string.startIndex
+        let mediatype = String(string[mediatypeRange])
+        
+        let charset: String?
+        if match.range(at: 2).location != NSNotFound,
+           let charsetRange = Range(match.range(at: 2), in: string)
+        {
+            charset = String(string[charsetRange])
+        } else {
+            charset = nil
+        }
+        
+        guard let encodedDataRange = Range(match.range(at: 3), in: string) else {
+            return nil
+        }
+        let encodedData = String(string[encodedDataRange])
 
         let isBase64 = string.contains(";base64,")
 
         // Process MIME type
-        var mimeType = mediatype.isEmpty ? "text/plain" : String(mediatype)
+        var mimeType = mediatype.isEmpty ? "text/plain" : mediatype
         if let charset = charset, !charset.isEmpty, mimeType.starts(with: "text/") {
             mimeType += ";charset=\(charset)"
         }
@@ -62,11 +140,11 @@ extension Data {
         // Decode data
         let decodedData: Data
         if isBase64 {
-            guard let base64Data = Data(base64Encoded: String(encodedData)) else { return nil }
+            guard let base64Data = Data(base64Encoded: encodedData) else { return nil }
             decodedData = base64Data
         } else {
             guard
-                let percentDecodedData = String(encodedData).removingPercentEncoding?.data(
+                let percentDecodedData = encodedData.removingPercentEncoding?.data(
                     using: .utf8)
             else { return nil }
             decodedData = percentDecodedData

--- a/Sources/Ollama/JSONSchema.swift
+++ b/Sources/Ollama/JSONSchema.swift
@@ -1,0 +1,338 @@
+import Foundation
+
+/// A protocol that types can conform to to provide their JSON schema representation.
+///
+/// Types conforming to this protocol can provide a custom JSON schema
+/// that will be used when generating structured outputs.
+///
+/// **Note:** For many simple types, you don't need to implement this protocol!
+/// The `JSONSchemaGenerator` can automatically generate schemas for types where:
+/// - All properties are optional (can be decoded from empty JSON `{}`)
+/// - The type structure can be inferred via runtime introspection
+///
+/// **Important:** When using automatic schema generation, all properties are marked as
+/// `required` in the JSON schema (even if they're optional in Swift). This ensures the
+/// model returns all fields in its response. Your Swift types can still be optional for
+/// decoding flexibility.
+///
+/// You only need to implement `jsonSchema` when:
+/// - You want to make some fields truly optional in the JSON schema (not required)
+/// - You want to add descriptions, constraints, or other schema metadata
+/// - Automatic generation doesn't work for your specific type
+///
+/// - Example with automatic schema generation (no jsonSchema needed):
+/// ```swift
+/// struct Country: Codable {
+///     let name: String?
+///     let capital: String?
+///     let languages: [String]?
+/// }
+///
+/// // Schema is automatically generated with all fields marked as required!
+/// // This ensures the model returns name, capital, and languages.
+/// let (country, _) = try await client.chat(
+///     model: "llama3.2",
+///     messages: [.user("Tell me about Canada.")],
+///     responseType: Country.self
+/// )
+/// ```
+///
+/// - Example with custom schema (for required fields):
+/// ```swift
+/// struct Country: Codable, JSONSchemaRepresentable {
+///     let name: String
+///     let capital: String
+///     let languages: [String]
+///     
+///     static var jsonSchema: Value {
+///         [
+///             "type": "object",
+///             "properties": [
+///                 "name": ["type": "string"],
+///                 "capital": ["type": "string"],
+///                 "languages": [
+///                     "type": "array",
+///                     "items": ["type": "string"]
+///                 ]
+///             ],
+///             "required": ["name", "capital", "languages"]
+///         ]
+///     }
+/// }
+/// ```
+public protocol JSONSchemaRepresentable {
+    /// Returns the JSON schema for this type as a `Value`.
+    static var jsonSchema: Value { get }
+}
+
+/// A utility for generating JSON schemas from Swift Codable types.
+public enum JSONSchemaGenerator {
+    /// Generates a JSON schema from a Codable type.
+    ///
+    /// This method first checks if the type conforms to `JSONSchemaRepresentable`
+    /// and uses its custom schema. Otherwise, it attempts to automatically generate
+    /// a schema by analyzing the type structure using runtime introspection.
+    ///
+    /// **Automatic schema generation works best when:**
+    /// - All properties in your type are optional (can decode from `{}`)
+    /// - Your type uses standard Swift types (String, Int, Double, Bool, Array, etc.)
+    ///
+    /// For types with required properties, consider implementing `JSONSchemaRepresentable`
+    /// to provide a custom schema with proper `required` fields.
+    ///
+    /// - Parameter type: The Codable type to generate a schema for
+    /// - Returns: A JSON schema as a `Value` object
+    /// - Throws: An error if the schema cannot be generated
+    public static func schema<T: Codable>(for type: T.Type) throws -> Value {
+        // If the type conforms to JSONSchemaRepresentable, use its custom schema
+        if let representable = type as? any JSONSchemaRepresentable.Type {
+            return representable.jsonSchema
+        }
+        
+        // Otherwise, generate schema from Codable introspection
+        return try generateSchema(for: type)
+    }
+    
+    private static func generateSchema<T: Codable>(for type: T.Type) throws -> Value {
+        // For primitive types, return their schema directly
+        if let primitiveSchema = primitiveSchema(for: type) {
+            return primitiveSchema
+        }
+        
+        // For arrays, try to generate schema for the element type
+        if let arrayType = type as? any ArrayTypeProtocol.Type {
+            // Try to generate schema for array of the element type
+            // We'll use a helper that works with Any.Type
+            let elementSchema = try schemaForAnyType(arrayType.elementType)
+            return [
+                "type": "array",
+                "items": elementSchema
+            ]
+        }
+        
+        // For optionals, generate schema for the wrapped type
+        if let optionalType = type as? any OptionalTypeProtocol.Type {
+            // Generate schema for the wrapped type
+            let wrappedSchema = try schemaForAnyType(optionalType.wrappedType)
+            return wrappedSchema
+        }
+        
+        // For complex types (structs, classes), we need to use a sample instance
+        // This requires the type to be initializable or have a way to create a sample
+        return try objectSchema(for: type)
+    }
+    
+    // Helper function to generate schema from Any.Type
+    // This allows us to handle arrays and optionals recursively
+    private static func schemaForAnyType(_ anyType: Any.Type) throws -> Value {
+        // Check for JSONSchemaRepresentable first
+        if let representable = anyType as? any JSONSchemaRepresentable.Type {
+            return representable.jsonSchema
+        }
+        
+        // Handle primitive types
+        if anyType == String.self {
+            return ["type": "string"]
+        } else if anyType == Int.self || anyType == Int8.self || anyType == Int16.self ||
+                  anyType == Int32.self || anyType == Int64.self ||
+                  anyType == UInt.self || anyType == UInt8.self || anyType == UInt16.self ||
+                  anyType == UInt32.self || anyType == UInt64.self {
+            return ["type": "integer"]
+        } else if anyType == Double.self || anyType == Float.self {
+            return ["type": "number"]
+        } else if anyType == Bool.self {
+            return ["type": "boolean"]
+        }
+        
+        // For arrays, recurse
+        if let arrayType = anyType as? any ArrayTypeProtocol.Type {
+            let elementSchema = try schemaForAnyType(arrayType.elementType)
+            return [
+                "type": "array",
+                "items": elementSchema
+            ]
+        }
+        
+        // For optionals, recurse
+        if let optionalType = anyType as? any OptionalTypeProtocol.Type {
+            return try schemaForAnyType(optionalType.wrappedType)
+        }
+        
+        // Default to object for complex types
+        // Users should provide custom schemas via JSONSchemaRepresentable for best results
+        return [
+            "type": "object",
+            "properties": [:],
+            "required": []
+        ]
+    }
+    
+    private static func primitiveSchema<T>(for type: T.Type) -> Value? {
+        if type == String.self {
+            return ["type": "string"]
+        } else if type == Int.self || type == Int8.self || type == Int16.self || 
+                  type == Int32.self || type == Int64.self || 
+                  type == UInt.self || type == UInt8.self || type == UInt16.self ||
+                  type == UInt32.self || type == UInt64.self {
+            return ["type": "integer"]
+        } else if type == Double.self || type == Float.self {
+            return ["type": "number"]
+        } else if type == Bool.self {
+            return ["type": "boolean"]
+        }
+        return nil
+    }
+    
+    private static func objectSchema<T: Codable>(for type: T.Type) throws -> Value {
+        // Use Mirror to introspect the type structure
+        // This allows us to automatically generate schemas without manual definition
+        return try mirrorBasedSchema(for: type)
+    }
+    
+    private static func mirrorBasedSchema<T: Codable>(for type: T.Type) throws -> Value {
+        // Try to create a sample instance to inspect
+        // We'll attempt multiple strategies to create an instance
+        
+        // Strategy 1: Try to decode from empty JSON (works if all fields are optional)
+        let emptyJSON = "{}".data(using: .utf8)!
+        let decoder = JSONDecoder()
+        
+        if let instance = try? decoder.decode(type, from: emptyJSON) {
+            // All fields are optional, but we can still inspect the structure
+            return try schemaFromInstance(instance)
+        }
+        
+        // Strategy 2: Try to create an instance with default values
+        if let instance = try? createInstanceWithDefaults(type) {
+            return try schemaFromInstance(instance)
+        }
+        
+        // Strategy 3: Fallback - return generic schema
+        // Users can provide custom schema via JSONSchemaRepresentable for best results
+        return try schemaFromTypeMetadata(type)
+    }
+    
+    private static func createInstanceWithDefaults<T: Codable>(_ type: T.Type) throws -> T? {
+        // Try to create an instance by encoding a JSON with default values
+        // This works for types that can handle missing or default values
+        
+        // Strategy: Create a JSON with null/default values and try to decode
+        // This is limited but works for some cases
+        
+        // For structs with default initializers, we could try that
+        // But Swift doesn't provide a way to check for default init at runtime
+        
+        // Alternative: Try decoding with a JSON that has null for all possible keys
+        // This requires knowing the keys, which we don't have without an instance
+        
+        // For now, this is a placeholder
+        // The best automatic generation works when:
+        // 1. All properties are optional (can decode from {})
+        // 2. Type provides custom schema via JSONSchemaRepresentable
+        // 3. Type has a default initializer (we'd need Swift macros to detect this)
+        
+        return nil
+    }
+    
+    private static func schemaFromInstance<T: Codable>(_ instance: T) throws -> Value {
+        let mirror = Mirror(reflecting: instance)
+        var properties: [String: Value] = [:]
+        var required: [String] = []
+        
+        for child in mirror.children {
+            guard let label = child.label else { continue }
+            
+            // Remove the underscore prefix that Swift adds to property names
+            let propertyName = label.hasPrefix("_") ? String(label.dropFirst()) : label
+            
+            // Determine the type and whether it's optional
+            let valueType = type(of: child.value)
+            let isOptional = valueType is any OptionalTypeProtocol.Type
+            
+            // Generate schema for the property type
+            let propertySchema: Value
+            if isOptional {
+                // For optionals, get the wrapped type
+                if let optionalType = valueType as? any OptionalTypeProtocol.Type {
+                    propertySchema = try schemaForAnyType(optionalType.wrappedType)
+                } else {
+                    propertySchema = ["type": "object"]
+                }
+            } else {
+                propertySchema = try schemaForAnyType(valueType)
+            }
+            
+            properties[propertyName] = propertySchema
+            
+            // Always add to required array, even if optional in Swift
+            // This ensures the model returns all fields in the response
+            // The Swift type can still be optional for decoding flexibility
+            required.append(propertyName)
+        }
+        
+        return [
+            "type": "object",
+            "properties": .object(properties),
+            "required": .array(required.map { .string($0) })
+        ]
+    }
+    
+    private static func schemaFromTypeMetadata<T: Codable>(_ type: T.Type) throws -> Value {
+        // For types we can't instantiate, try to use Mirror on the type itself
+        // This is more limited but can still provide some information
+        
+        // Try to create a minimal instance by attempting to decode with various strategies
+        // If that fails, return a generic object schema
+        
+        // Attempt to get type information through encoding a dummy value
+        // This is a fallback - the best approach is to have an instance
+        
+        // For now, return a generic schema with a note that custom schema is recommended
+        // In practice, users should either:
+        // 1. Provide a custom schema via JSONSchemaRepresentable
+        // 2. Ensure their type can be decoded from empty JSON (all optionals)
+        // 3. Use a type that we can inspect via Mirror
+        
+        return [
+            "type": "object",
+            "properties": [:],
+            "required": []
+        ]
+    }
+}
+
+// MARK: - Type Introspection Helpers
+
+private protocol ArrayTypeProtocol {
+    static var elementType: Any.Type { get }
+}
+
+extension Array: ArrayTypeProtocol {
+    static var elementType: Any.Type {
+        Element.self
+    }
+}
+
+private protocol OptionalTypeProtocol {
+    static var wrappedType: Any.Type { get }
+}
+
+extension Optional: OptionalTypeProtocol {
+    static var wrappedType: Any.Type {
+        Wrapped.self
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension JSONSchemaGenerator {
+    /// Generates a JSON schema from a Codable type instance.
+    ///
+    /// - Parameter instance: An instance of the Codable type
+    /// - Returns: A JSON schema as a `Value` object
+    /// - Throws: An error if the schema cannot be generated
+    public static func schema<T: Codable>(from instance: T) throws -> Value {
+        return try schema(for: type(of: instance))
+    }
+}
+

--- a/Sources/Ollama/JSONSchema.swift
+++ b/Sources/Ollama/JSONSchema.swift
@@ -1,14 +1,41 @@
 import Foundation
 
+/// A protocol that types can conform to to provide an example instance for schema generation.
+///
+/// Types conforming to this protocol can provide an example instance that will be used
+/// to automatically generate a JSON schema. This is the recommended approach for types
+/// with required properties, as it guarantees accurate schema generation.
+///
+/// - Example:
+/// ```swift
+/// struct Country: Codable, JSONSchemaExample {
+///     let name: String
+///     let capital: String
+///     let languages: [String]
+///     
+///     static var example: Country {
+///         Country(
+///             name: "Canada",
+///             capital: "Ottawa",
+///             languages: ["English", "French"]
+///         )
+///     }
+/// }
+/// ```
+public protocol JSONSchemaExample {
+    /// An example instance of this type used to generate the JSON schema.
+    static var example: Self { get }
+}
+
 /// A protocol that types can conform to to provide their JSON schema representation.
 ///
 /// Types conforming to this protocol can provide a custom JSON schema
 /// that will be used when generating structured outputs.
 ///
 /// **Note:** For many simple types, you don't need to implement this protocol!
-/// The `JSONSchemaGenerator` can automatically generate schemas for types where:
-/// - All properties are optional (can be decoded from empty JSON `{}`)
-/// - The type structure can be inferred via runtime introspection
+/// The `JSONSchemaGenerator` can automatically generate schemas using:
+/// - `JSONSchemaExample` protocol (recommended for types with required properties)
+/// - Automatic introspection (works for types with all optional properties)
 ///
 /// **Important:** When using automatic schema generation, all properties are marked as
 /// `required` in the JSON schema (even if they're optional in Swift). This ensures the
@@ -20,7 +47,31 @@ import Foundation
 /// - You want to add descriptions, constraints, or other schema metadata
 /// - Automatic generation doesn't work for your specific type
 ///
-/// - Example with automatic schema generation (no jsonSchema needed):
+/// - Example with JSONSchemaExample (recommended for required properties):
+/// ```swift
+/// struct Country: Codable, JSONSchemaExample {
+///     let name: String
+///     let capital: String
+///     let languages: [String]
+///     
+///     static var example: Country {
+///         Country(
+///             name: "Canada",
+///             capital: "Ottawa",
+///             languages: ["English", "French"]
+///         )
+///     }
+/// }
+///
+/// // Schema is automatically generated from the example!
+/// let (country, _) = try await client.chat(
+///     model: "llama3.2",
+///     messages: [.user("Tell me about Canada.")],
+///     responseType: Country.self
+/// )
+/// ```
+///
+/// - Example with automatic schema generation (for optional properties):
 /// ```swift
 /// struct Country: Codable {
 ///     let name: String?
@@ -29,7 +80,6 @@ import Foundation
 /// }
 ///
 /// // Schema is automatically generated with all fields marked as required!
-/// // This ensures the model returns name, capital, and languages.
 /// let (country, _) = try await client.chat(
 ///     model: "llama3.2",
 ///     messages: [.user("Tell me about Canada.")],
@@ -73,23 +123,30 @@ public enum JSONSchemaGenerator {
     /// and uses its custom schema. Otherwise, it attempts to automatically generate
     /// a schema by analyzing the type structure using runtime introspection.
     ///
-    /// **Automatic schema generation works best when:**
-    /// - All properties in your type are optional (can decode from `{}`)
-    /// - Your type uses standard Swift types (String, Int, Double, Bool, Array, etc.)
+    /// **Automatic schema generation works in this order:**
+    /// 1. If type conforms to `JSONSchemaExample` - uses the example instance (works for all types!)
+    /// 2. If all properties are optional - can decode from `{}` and introspect
+    /// 3. Otherwise - attempts heuristics (may not always succeed)
     ///
-    /// For types with required properties, consider implementing `JSONSchemaRepresentable`
-    /// to provide a custom schema with proper `required` fields.
+    /// **Recommended approach:** Conform to `JSONSchemaExample` for types with required properties.
+    /// This guarantees accurate schema generation without manual schema definition.
     ///
     /// - Parameter type: The Codable type to generate a schema for
     /// - Returns: A JSON schema as a `Value` object
     /// - Throws: An error if the schema cannot be generated
     public static func schema<T: Codable>(for type: T.Type) throws -> Value {
-        // If the type conforms to JSONSchemaRepresentable, use its custom schema
+        // Priority 1: If the type conforms to JSONSchemaRepresentable, use its custom schema
         if let representable = type as? any JSONSchemaRepresentable.Type {
             return representable.jsonSchema
         }
         
-        // Otherwise, generate schema from Codable introspection
+        // Priority 2: If the type conforms to JSONSchemaExample, use the example to generate schema
+        if let exampleType = type as? any JSONSchemaExample.Type {
+            let exampleInstance = exampleType.example
+            return try schemaFromInstance(exampleInstance as! T)
+        }
+        
+        // Priority 3: Otherwise, generate schema from Codable introspection
         return try generateSchema(for: type)
     }
     
@@ -333,6 +390,32 @@ extension JSONSchemaGenerator {
     /// - Throws: An error if the schema cannot be generated
     public static func schema<T: Codable>(from instance: T) throws -> Value {
         return try schema(for: type(of: instance))
+    }
+    
+    /// Generates a JSON schema from a type that provides an example instance.
+    ///
+    /// This is similar to the `derivedJsonSchema` method in other SDKs.
+    /// The type must conform to `JSONSchemaExample` to provide an example instance.
+    ///
+    /// - Parameter type: A type conforming to `JSONSchemaExample`
+    /// - Returns: A JSON schema as a `Value` object
+    /// - Throws: An error if the schema cannot be generated
+    ///
+    /// - Example:
+    /// ```swift
+    /// struct Country: Codable, JSONSchemaExample {
+    ///     let name: String
+    ///     let capital: String
+    ///     
+    ///     static var example: Country {
+    ///         Country(name: "Canada", capital: "Ottawa")
+    ///     }
+    /// }
+    ///
+    /// let schema = try JSONSchemaGenerator.derivedJsonSchema(Country.self)
+    /// ```
+    public static func derivedJsonSchema<T: Codable & JSONSchemaExample>(_ type: T.Type) throws -> Value {
+        return try schema(for: type)
     }
 }
 


### PR DESCRIPTION
In this PR, I provided three new methods for structured output schema to improve ergonomic. 
1. Zod style schema. To define an example for the model, then the schema can be automatically generated.

```swift
import Ollama

struct Country: Codable, JSONSchemaExample {
    let name: String
    let capital: String
    let languages: [String]

    static var example: Country {
        Country(
            name: "Canada",
            capital: "Ottawa",
            languages: ["English", "French"]
        )
    }
}

// Schema is automatically generated from the example!
// The response is automatically decoded to your type
let (country, _) = try await client.chat(
    model: "llama3.2",
    messages: [.user("Tell me about Canada.")],
    responseType: Country.self
)

print(country.name)      // "Canada"
print(country.capital)   // "Ottawa"
print(country.languages) // ["English", "French"]
```
2. Make all properties optional

```swift
struct Color: Codable {
    let name: String?
    let hex: String?
    let rgb: [Int]?
}

// Works automatically - no example needed!
let (color, _) = try await client.chat(
    model: "llama3.2",
    messages: [.user("Give me a color and its hex code.")],
    responseType: Color.self
)
```

3. Define schema inside the model
```swift
struct Country: Codable, JSONSchemaRepresentable {
    let name: String
    let capital: String
    let languages: [String]

    static var jsonSchema: Value {
        [
            "type": "object",
            "properties": [
                "name": ["type": "string", "description": "Country name"],
                "capital": ["type": "string", "description": "Capital city"],
                "languages": [
                    "type": "array",
                    "items": ["type": "string"],
                    "description": "Official languages"
                ]
            ],
            "required": ["name", "capital", "languages"]
        ]
    }
}

let (country, _) = try await client.chat(
    model: "llama3.2",
    messages: [.user("Tell me about Canada.")],
    responseType: Country.self
)
```